### PR TITLE
Allow for pulling of config via URL

### DIFF
--- a/lib/nugget.rb
+++ b/lib/nugget.rb
@@ -6,6 +6,7 @@ require 'mixlib/config'
 require 'mixlib/log'
 require 'yajl/json_gem'
 require 'thin'
+require 'open-uri'
 
 __DIR__ = File.dirname(__FILE__)
 

--- a/lib/nugget/service.rb
+++ b/lib/nugget/service.rb
@@ -18,7 +18,7 @@ module Nugget
     end
 
     def self.run()
-      config_file = File.new(Nugget::Config.config, 'r')
+      config_file = open(Nugget::Config.config)
       parser = Yajl::Parser.new(:symbolize_keys => true)
       config = parser.parse(config_file)
 


### PR DESCRIPTION
Howdy!

I was wanting nugget to pull the config from a local file _or_ a url.  This makes that possible.

The approach is pretty naive, and ties the process to the availability of the url.  I'm happy to expand this more to include some amount of retrying / caching in the event of the URL going unavailable in subsequent calls to `run`, but wanted to get your take on it before doing so.  I assume it is your intent to have the config reloaded at every for the sake of config updates.
